### PR TITLE
🔐(custom_ca) persist the custom cert in a secret

### DIFF
--- a/kind/create_cluster.sh
+++ b/kind/create_cluster.sh
@@ -151,4 +151,5 @@ if ! kubectl get configmap certifi -n ${APPLICATION}; then
 	curl https://raw.githubusercontent.com/certifi/python-certifi/refs/heads/master/certifi/cacert.pem -o /tmp/cacert.pem
 	cat "$(mkcert -CAROOT)/rootCA.pem" >>/tmp/cacert.pem
 	kubectl -n ${APPLICATION} create configmap certifi --from-file=cacert.pem=/tmp/cacert.pem
+	kubectl -n ${APPLICATION} create secret generic certifi --from-file=/tmp/cacert.pem
 fi


### PR DESCRIPTION
This allows to use also the custom certificate from a secret as required by the bitnami keycloak helm chart.

See https://github.com/bitnami/charts/blob/keycloak/24.4.8/bitnami/keycloak/values.yaml#L151